### PR TITLE
Update hosts

### DIFF
--- a/hosts
+++ b/hosts
@@ -16,6 +16,7 @@
 127.0.0.1 p16-tiktokcdn-com.akamaized.net
 127.0.0.1 t.tiktok.com
 127.0.0.1 tiktok.com
+127.0.0.1 www.tiktok.com
 127.0.0.1 tiktok.org
 127.0.0.1 tiktokcdn-com.akamaized.net
 127.0.0.1 tiktokcdn.com


### PR DESCRIPTION
added www.tiktok.org for effective blocking when the browser tacks on www.